### PR TITLE
Fix bug when converting OSDT leaves into a Text Classifier compatible…

### DIFF
--- a/python/model/gosdt.py
+++ b/python/model/gosdt.py
@@ -306,9 +306,24 @@ class GOSDT:
             }
         else:
             features = {}
+            # In next commented section there is a bug when trying to validate if a leaf exists in the "features" dict. Essentially, a "leaf" has 
+            # the form: (feature_1, feature_2, ..., feature_n) and the "keys" and "values" of the "features" dict has the form:
+            # key = feature
+            # value = frequency
+            # So, the condition must be changed in order to evaluate the case when a "feature" from the current "leaf" exists in the "features" dict
+            # Otherwise, for some specific cases this loop crashes
+            # ------ Original loop ---------- #
+            # for leaf in leaves.keys():
+            #     if not leaf in features:
+            #         for e in leaf:
+            #             features[abs(e)] = 1
+            #         else:
+            #             features[abs(e)] += 1
+
+            # ------ Fixed loop ---------- #
             for leaf in leaves.keys():
-                if not leaf in features:
-                    for e in leaf:
+                for e in leaf:
+                    if abs(e) not in features.keys():
                         features[abs(e)] = 1
                     else:
                         features[abs(e)] += 1


### PR DESCRIPTION
There is a bug when trying to validate if a `leaf` exists in the `features` dict. Essentially, a` leaf` is a tuple with form:

` (feature_1, feature_2, ..., feature_n)` 

and the `keys` and `values` of the `features` dict has the form:

```
key = feature
value = frequency
```

where 

```
feature: int
frequency: int
```

So the original `if-else` statement, tried to validate if a tuple was in `features`, however features only contain integers for key and values. For some specific cases, it returned an empty dict which turn out into a recursivity problem.